### PR TITLE
Update to ts-morph and typescript 3.5.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,18 +23,18 @@
     "command-line-usage": "^5.0.5",
     "lodash": "^4.17.10",
     "make-error": "^1.3.4",
-    "ts-simple-ast": "^21.0.0"
+    "tsconfig": "^7.0.0",
+    "ts-morph": "^3.1.0",
+    "typescript": "^3.5.3"
   },
   "devDependencies": {
     "@types/node": "^11.9.0",
-    "typescript": "^3.1.6",
     "@types/tape": "^4.2.32",
     "@types/uglify-js": "^3.0.3",
     "prettier": "^1.14.2",
     "tap-diff": "^0.1.1",
     "tape": "^4.9.1",
     "ts-node": "^8.0.3",
-    "tsconfig": "^7.0.0",
     "tslint": "^5.11.0",
     "tslint-config-prettier": "^1.15.0",
     "uglify-js": "^3.4.9"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,7 +5,7 @@
 import commandLineArgs from 'command-line-args'
 import commandLineUsage from 'command-line-usage'
 import { defaults } from 'lodash'
-import { FileNotFoundError } from 'ts-simple-ast'
+import { FileNotFoundError } from 'ts-morph'
 import * as TsConfig from 'tsconfig'
 import { generate } from './index'
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,16 +1,18 @@
 import { flatMap, lowerFirst } from 'lodash'
-import Project, {
+import {
   ExportableNode,
   ImportDeclarationStructure,
   JSDoc,
   JSDocableNode,
   Node,
+  Project,
   PropertySignature,
   SourceFile,
+  StructureKind,
   SyntaxKind,
   Type,
   TypeGuards,
-} from 'ts-simple-ast'
+} from 'ts-morph'
 
 // -- Helpers --
 
@@ -443,7 +445,7 @@ function typeConditions(
   if (type.isArray()) {
     return arrayCondition(
       varName,
-      type.getArrayType()!,
+      type.getArrayElementType()!,
       addDependency,
       project,
       path,
@@ -597,10 +599,10 @@ function findOrCreate(project: Project, path: string): SourceFile {
   return outFile
 }
 
-interface Imports {
+interface IImports {
   [exportName: string]: string
 }
-type Dependencies = Map<SourceFile, Imports>
+type Dependencies = Map<SourceFile, IImports>
 type IAddDependency = (
   sourceFile: SourceFile,
   exportName: string,
@@ -748,11 +750,12 @@ export function processProject(
             )
             const defaultImport = imports.default
             delete imports.default
-            const namedImports = Object.entries(imports).map(
-              ([alias, name]) => (alias === name ? name : { name, alias })
+            const namedImports = Object.entries(imports).map(([alias, name]) =>
+              alias === name ? name : { name, alias }
             )
             structures.push({
               defaultImport,
+              kind: StructureKind.ImportDeclaration,
               moduleSpecifier,
               namedImports,
             })


### PR DESCRIPTION
ts-simple-ast is crashing with current typescript versions because [this call](https://github.com/microsoft/TypeScript/blob/4f3412153a63847937bf0e8ea0122ca1e1f95ffe/src/compiler/utilities.ts#L8118) is missing a parameter.

